### PR TITLE
Change group view icon to a cross

### DIFF
--- a/web/src/admin/groups/GroupListPage.ts
+++ b/web/src/admin/groups/GroupListPage.ts
@@ -80,7 +80,7 @@ export class GroupListPage extends TablePage<Group> {
             html`<a href="#/identity/groups/${item.pk}">${item.name}</a>`,
             html`${item.parentName || msg("-")}`,
             html`${Array.from(item.users || []).length}`,
-            html`<ak-status-label type="info" ?good=${item.isSuperuser}></ak-status-label>`,
+            html`<ak-status-label type="neutral" ?good=${item.isSuperuser}></ak-status-label>`,
             html`<ak-forms-modal>
                 <span slot="submit"> ${msg("Update")} </span>
                 <span slot="header"> ${msg("Update Group")} </span>

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -118,7 +118,7 @@ export class GroupViewPage extends AKElement {
                                     <dd class="pf-c-description-list__description">
                                         <div class="pf-c-description-list__text">
                                             <ak-status-label
-                                                type="info"
+                                                type="neutral"
                                                 ?good=${this.group.isSuperuser}
                                             ></ak-status-label>
                                         </div>

--- a/web/src/admin/groups/RelatedGroupList.ts
+++ b/web/src/admin/groups/RelatedGroupList.ts
@@ -144,7 +144,7 @@ export class RelatedGroupList extends Table<Group> {
         return [
             html`<a href="#/identity/groups/${item.pk}">${item.name}</a>`,
             html`${item.parentName || msg("-")}`,
-            html`<ak-label type="info" ?good=${item.isSuperuser}></ak-label>`,
+            html`<ak-status-label type="neutral" ?good=${item.isSuperuser}></ak-status-label>`,
             html` <ak-forms-modal>
                 <span slot="submit"> ${msg("Update")} </span>
                 <span slot="header"> ${msg("Update Group")} </span>

--- a/web/src/admin/users/GroupSelectModal.ts
+++ b/web/src/admin/users/GroupSelectModal.ts
@@ -50,7 +50,7 @@ export class GroupSelectModal extends TableModal<Group> {
             html`<div>
                 <div>${item.name}</div>
             </div>`,
-            html` <ak-status-label type="info" ?good=${item.isSuperuser}></ak-status-label>`,
+            html` <ak-status-label type="neutral" ?good=${item.isSuperuser}></ak-status-label>`,
             html`${(item.users || []).length}`,
         ];
     }

--- a/web/src/components/ak-status-label.ts
+++ b/web/src/components/ak-status-label.ts
@@ -11,13 +11,14 @@ import PFBase from "@patternfly/patternfly/patternfly-base.css";
 // The 'const ... as const' construction will throw a compilation error if the const variable is
 // only ever used to generate the type information, so the `_` (ignore unused variable) prefix must
 // be used here.
-const _statusNames = ["error", "warning", "info"] as const;
+const _statusNames = ["error", "warning", "info", "neutral"] as const;
 type StatusName = (typeof _statusNames)[number];
 
 const statusToDetails = new Map<StatusName, [string, string]>([
     ["error", ["pf-m-red", "fa-times"]],
     ["warning", ["pf-m-orange", "fa-exclamation-triangle"]],
     ["info", ["pf-m-gray", "fa-info-circle"]],
+    ["neutral", ["pf-m-gray", "fa-times"]],
 ]);
 
 const styles = css`
@@ -64,6 +65,7 @@ const styles = css`
  * - type="error" (default): A Red ✖
  * - type="warning" An orange ⚠
  * - type="info" A grey ⓘ
+ * - type="neutral" A grey ✖
  *
  * By default, the messages for "good" and "other" are "Yes" and "No" respectively, but these can be
  * customized with the attributes `good-label` and `bad-label`.


### PR DESCRIPTION
## Details

Replaces the confusing 'info' icon with a new 'neutral' status (grey cross) for non-superuser groups in various group views and lists. The 'info' icon was misleading as not being a superuser is a neutral state, not an informational one or an error, improving clarity for users.

---

## Checklist

-   [ ] Local tests pass (`ak test authentik/`)
-   [ ] The code has been formatted (`make lint-fix`)

If an API change has been made

-   [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

-   [ ] The code has been formatted (`make web`)

If applicable

-   [ ] The documentation has been updated
-   [ ] The documentation has been formatted (`make docs`)

---
<a href="https://cursor.com/background-agent?bcId=bc-a42f91b8-1472-4117-8c94-18128499884a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a42f91b8-1472-4117-8c94-18128499884a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

