### PR TITLE
Fix ak-search-select selection when value functions return numbers

### DIFF
--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -243,7 +243,8 @@ export abstract class SearchSelectBase<T>
 
             return;
         }
-        const selected = this.objects?.find((obj) => this.value(obj) === value) || null;
+        const selected =
+            this.objects?.find((obj) => `${this.value(obj) ?? ""}` === value) || null;
 
         if (!selected) {
             console.warn(`ak-search-select: No corresponding object found for value (${value}`);


### PR DESCRIPTION
## Summary
- normalize the ak-search-select comparison logic so options chosen via numeric values are detected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16c99d9f08323b2b40ea947685f33